### PR TITLE
feat: 피드 바텀시트 구현

### DIFF
--- a/app/src/main/java/com/grusie/sharingmap/designsystem/component/Comment.kt
+++ b/app/src/main/java/com/grusie/sharingmap/designsystem/component/Comment.kt
@@ -1,0 +1,140 @@
+package com.grusie.sharingmap.designsystem.component
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.text2.input.rememberTextFieldState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.grusie.sharingmap.R
+import com.grusie.sharingmap.designsystem.theme.Black
+import com.grusie.sharingmap.designsystem.theme.Gray400
+import com.grusie.sharingmap.designsystem.theme.GrayA8AAAB
+import com.grusie.sharingmap.designsystem.theme.Typography
+import com.grusie.sharingmap.designsystem.util.singleClickable
+import com.grusie.sharingmap.ui.model.CommentUiModel
+import com.grusie.sharingmap.ui.model.UserUiModel
+import java.time.LocalDate
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun CommentContent(
+    comments: List<CommentUiModel>,
+    modifier: Modifier = Modifier,
+) {
+    val comment = rememberTextFieldState()
+    Column(modifier = modifier.fillMaxWidth()) {
+        CommentLazyColumn(comments = comments)
+        CustomTextField(textFieldState = comment)
+        Spacer(modifier = Modifier.height(34.dp))
+    }
+}
+
+@Composable
+fun CommentLazyColumn(
+    comments: List<CommentUiModel>,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier = Modifier.fillMaxWidth().fillMaxHeight(0.5f)) {
+        itemsIndexed(comments) { _, comment ->
+            CommentItem(comment = comment, isFollow = true, onMeatBallClick = {}, onFollowClick = {})
+        }
+    }
+}
+
+@Composable
+fun CommentItem(
+    comment: CommentUiModel,
+    isFollow: Boolean,
+    onMeatBallClick: () -> Unit,
+    onFollowClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 14.dp),
+        ) {
+            ProfileImage(profileImage = comment.user.profileImage, isFollow = isFollow, onAddClick = { onFollowClick() })
+            Spacer(modifier = Modifier.width(9.dp))
+            Column(
+                modifier =
+                    modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .padding(vertical = 1.dp),
+            ) {
+                Text(
+                    text = comment.user.name,
+                    style = Typography.bodySmall,
+                    color = Black,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(5.dp))
+                Text(
+                    text = comment.date.toString(),
+                    style = Typography.labelSmall,
+                    color = Gray400,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            Image(
+                painter = painterResource(id = R.drawable.btn_meatball),
+                contentDescription = null,
+                modifier = Modifier.singleClickable { onMeatBallClick() },
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = comment.content,
+            style = Typography.bodyMedium,
+            modifier =
+                modifier
+                    .fillMaxWidth()
+                    .padding(start = 57.dp, end = 14.dp),
+        )
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(text = "댓글달기", style = Typography.bodyMedium, color = GrayA8AAAB, modifier = modifier.padding(start = 57.dp, end = 14.dp))
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Preview
+@Composable
+private fun CommentPreview() {
+    CommentLazyColumn(
+        comments =
+            listOf(
+                CommentUiModel(
+                    id = 1,
+                    user =
+                        UserUiModel(
+                            id = 1,
+                            profileImage = "",
+                            name = "김민수",
+                        ),
+                    content = "안녕하세요",
+                    date = LocalDate.now(),
+                ),
+            ),
+    )
+}

--- a/app/src/main/java/com/grusie/sharingmap/designsystem/component/CustomBottomSheet.kt
+++ b/app/src/main/java/com/grusie/sharingmap/designsystem/component/CustomBottomSheet.kt
@@ -1,0 +1,186 @@
+package com.grusie.sharingmap.designsystem.component
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.grusie.sharingmap.designsystem.theme.Black
+import com.grusie.sharingmap.designsystem.theme.GrayE6E6E6
+import com.grusie.sharingmap.designsystem.theme.SharingMapTheme
+import com.grusie.sharingmap.designsystem.theme.Typography
+import com.grusie.sharingmap.designsystem.theme.White
+import com.grusie.sharingmap.ui.model.CommentUiModel
+import com.grusie.sharingmap.ui.model.UserUiModel
+import java.time.LocalDate
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CustomBottomSheet(
+    title: String,
+    content: @Composable () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true
+    )
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        shape = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp),
+        containerColor = White,
+        dragHandle = null,
+    ) {
+        Column(modifier = modifier.fillMaxWidth().wrapContentHeight()) {
+            HorizontalDivider(
+                modifier =
+                    Modifier
+                        .width(39.dp)
+                        .padding(top = 10.dp, bottom = 20.dp)
+                        .align(Alignment.CenterHorizontally),
+                thickness = 5.dp,
+                color = GrayE6E6E6,
+            )
+            Text(
+                text = title,
+                style = Typography.displayMedium,
+                color = Black,
+                modifier =
+                    modifier
+                        .padding(vertical = 4.dp)
+                        .align(Alignment.CenterHorizontally),
+            )
+            content()
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Preview
+@Composable
+fun CustomBottomSheetPreview(modifier: Modifier = Modifier) {
+    var showBottomSheet by remember { mutableStateOf(true) }
+
+    SharingMapTheme {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            if (showBottomSheet) {
+                CustomBottomSheet(title = "댓글", content = {
+                    CommentContent(
+                        comments =
+                            listOf(
+                                CommentUiModel(
+                                    id = 1,
+                                    user =
+                                        UserUiModel(
+                                            id = 1,
+                                            profileImage = "https://img.freepik.com/free-photo/adorable-kitty-looking-like-it-want-to-hunt_23-2149167099.jpg?w=2000",
+                                            name = "김민수",
+                                        ),
+                                    content = "안녕하세요",
+                                    date = LocalDate.now(),
+                                ),
+                                CommentUiModel(
+                                    id = 1,
+                                    user =
+                                        UserUiModel(
+                                            id = 1,
+                                            profileImage = "https://img.freepik.com/free-photo/adorable-kitty-looking-like-it-want-to-hunt_23-2149167099.jpg?w=2000",
+                                            name = "김민수",
+                                        ),
+                                    content = "안녕하세요",
+                                    date = LocalDate.now(),
+                                ),
+                                CommentUiModel(
+                                    id = 1,
+                                    user =
+                                        UserUiModel(
+                                            id = 1,
+                                            profileImage = "https://img.freepik.com/free-photo/adorable-kitty-looking-like-it-want-to-hunt_23-2149167099.jpg?w=2000",
+                                            name = "김민수",
+                                        ),
+                                    content = "안녕하세요",
+                                    date = LocalDate.now(),
+                                ),
+                                CommentUiModel(
+                                    id = 1,
+                                    user =
+                                        UserUiModel(
+                                            id = 1,
+                                            profileImage = "https://img.freepik.com/free-photo/adorable-kitty-looking-like-it-want-to-hunt_23-2149167099.jpg?w=2000",
+                                            name = "김민수",
+                                        ),
+                                    content = "안녕하세요",
+                                    date = LocalDate.now(),
+                                ),
+                                CommentUiModel(
+                                    id = 1,
+                                    user =
+                                        UserUiModel(
+                                            id = 1,
+                                            profileImage = "https://img.freepik.com/free-photo/adorable-kitty-looking-like-it-want-to-hunt_23-2149167099.jpg?w=2000",
+                                            name = "김민수",
+                                        ),
+                                    content = "안녕하세요",
+                                    date = LocalDate.now(),
+                                ),
+                                CommentUiModel(
+                                    id = 1,
+                                    user =
+                                        UserUiModel(
+                                            id = 1,
+                                            profileImage = "https://img.freepik.com/free-photo/adorable-kitty-looking-like-it-want-to-hunt_23-2149167099.jpg?w=2000",
+                                            name = "김민수",
+                                        ),
+                                    content = "안녕하세요",
+                                    date = LocalDate.now(),
+                                ),
+                                CommentUiModel(
+                                    id = 1,
+                                    user =
+                                        UserUiModel(
+                                            id = 1,
+                                            profileImage = "https://img.freepik.com/free-photo/adorable-kitty-looking-like-it-want-to-hunt_23-2149167099.jpg?w=2000",
+                                            name = "김민수",
+                                        ),
+                                    content = "안녕하세요",
+                                    date = LocalDate.now(),
+                                ),
+                                CommentUiModel(
+                                    id = 1,
+                                    user =
+                                        UserUiModel(
+                                            id = 1,
+                                            profileImage = "https://img.freepik.com/free-photo/adorable-kitty-looking-like-it-want-to-hunt_23-2149167099.jpg?w=2000",
+                                            name = "김민수",
+                                        ),
+                                    content = "안녕하세요",
+                                    date = LocalDate.now(),
+                                ),
+                            ),
+                    )
+                }, onDismiss = { showBottomSheet = false })
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/grusie/sharingmap/designsystem/component/CustomTextField.kt
+++ b/app/src/main/java/com/grusie/sharingmap/designsystem/component/CustomTextField.kt
@@ -1,0 +1,72 @@
+package com.grusie.sharingmap.designsystem.component
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text2.BasicTextField2
+import androidx.compose.foundation.text2.input.TextFieldState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.grusie.sharingmap.R
+import com.grusie.sharingmap.designsystem.theme.Gray100
+import com.grusie.sharingmap.designsystem.theme.Gray400
+import com.grusie.sharingmap.designsystem.theme.Typography
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun CustomTextField(
+    textFieldState: TextFieldState,
+    modifier: Modifier = Modifier.fillMaxWidth(),
+    cornerShape: RoundedCornerShape = RoundedCornerShape(12.dp),
+    backgroundColor: Color = Gray100,
+) {
+    BasicTextField2(
+        state = textFieldState,
+        modifier = modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+        keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+        textStyle = Typography.headlineSmall.copy(color = Gray400),
+        decorator = { innerTextField ->
+            Row(
+                modifier =
+                modifier
+                    .clip(shape = cornerShape)
+                    .background(color = backgroundColor)
+                    .padding(vertical = 15.dp)
+                    .padding(end = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Spacer(modifier = Modifier.padding(start = 16.dp))
+                if (textFieldState.text.isEmpty()) {
+                    Text(
+                        text = stringResource(id = R.string.feed_bottom_sheet_comment_hint_title),
+                        style = Typography.headlineSmall,
+                        color = Gray400,
+                    )
+                }
+                innerTextField()
+            }
+        },
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Preview
+@Composable
+private fun CustomTextFieldPreview() {
+    CustomTextField(textFieldState = TextFieldState(initialText = ""))
+    
+}

--- a/app/src/main/java/com/grusie/sharingmap/designsystem/component/Feed.kt
+++ b/app/src/main/java/com/grusie/sharingmap/designsystem/component/Feed.kt
@@ -47,10 +47,12 @@ import com.grusie.sharingmap.designsystem.util.singleClickable
 import com.grusie.sharingmap.ui.model.FeedInfoUiModel
 import com.grusie.sharingmap.ui.model.FeedUiModel
 import com.grusie.sharingmap.ui.model.LocationUiModel
+import com.grusie.sharingmap.ui.model.UserUiModel
 
 @Composable
 fun Feed(
     feed: FeedUiModel,
+    isFollow: Boolean,
     onProfileClick: () -> Unit,
     onImageClick: (String) -> Unit,
     onLocationClick: () -> Unit,
@@ -68,7 +70,7 @@ fun Feed(
                     .fillMaxWidth()
                     .padding(14.dp),
         ) {
-            ProfileImage(feed.profileImage, onProfileClick)
+            ProfileImage(feed.user.profileImage, isFollow, onProfileClick)
             Spacer(modifier = Modifier.width(9.dp))
             Column(
                 modifier =
@@ -78,7 +80,7 @@ fun Feed(
                         .padding(vertical = 1.dp),
             ) {
                 Text(
-                    text = feed.title,
+                    text = feed.user.name,
                     style = Typography.bodySmall,
                     color = Black,
                     modifier = Modifier.fillMaxWidth(),
@@ -114,6 +116,7 @@ fun Feed(
 @Composable
 fun ProfileImage(
     profileImage: String,
+    isFollow: Boolean,
     onAddClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -127,15 +130,17 @@ fun ProfileImage(
                     .clip(RoundedCornerShape(8.dp)),
             contentScale = ContentScale.Crop,
         )
-        Image(
-            painter = painterResource(id = R.drawable.btn_add_small),
-            contentDescription = null,
-            modifier =
-                Modifier
-                    .align(Alignment.BottomEnd)
-                    .offset(x = 0.5.dp, y = 0.5.dp)
-                    .singleClickable { onAddClick() },
-        )
+        if (!isFollow) {
+            Image(
+                painter = painterResource(id = R.drawable.btn_add_small),
+                contentDescription = null,
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomEnd)
+                        .offset(x = 0.5.dp, y = 0.5.dp)
+                        .singleClickable { onAddClick() },
+            )
+        }
     }
 }
 
@@ -388,8 +393,12 @@ fun ArchivingList(
 private fun FeedPreview() {
     Feed(
         FeedUiModel(
-            profileImage = "https://img.freepik.com/free-photo/adorable-kitty-looking-like-it-want-to-hunt_23-2149167099.jpg?w=2000",
-            title = "vocent",
+            user =
+                UserUiModel(
+                    id = 1,
+                    profileImage = "https://img.freepik.com/free-photo/adorable-kitty-looking-like-it-want-to-hunt_23-2149167099.jpg?w=2000",
+                    name = "김민수",
+                ),
             date = "2024.04.17",
             content = "honestatis",
             contentImages =
@@ -410,6 +419,7 @@ private fun FeedPreview() {
                     shareCount = 8829,
                 ),
         ),
+        isFollow = false,
         onProfileClick = {},
         onImageClick = {},
         onArchivingClick = {},

--- a/app/src/main/java/com/grusie/sharingmap/designsystem/component/User.kt
+++ b/app/src/main/java/com/grusie/sharingmap/designsystem/component/User.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,27 +19,43 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.grusie.sharingmap.designsystem.theme.Black
 import com.grusie.sharingmap.designsystem.theme.Typography
+import com.grusie.sharingmap.ui.model.UserUiModel
+
+@Composable
+fun UserLazyColumn(
+    users: List<UserUiModel>,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+        itemsIndexed(users) { index, user ->
+            UserItem(user)
+        }
+    }
+}
 
 @Composable
 fun UserItem(
-    profileImage: String,
-    name: String,
+    user: UserUiModel,
     modifier: Modifier = Modifier,
 ) {
     Row(modifier = modifier.padding(vertical = 8.dp, horizontal = 20.dp)) {
         AsyncImage(
-            model = profileImage,
+            model = user.profileImage,
             contentDescription = null,
-            modifier = Modifier
-                .size(32.dp)
-                .clip(RoundedCornerShape(8.dp)),
+            modifier =
+                Modifier
+                    .size(32.dp)
+                    .clip(RoundedCornerShape(8.dp)),
         )
         Spacer(modifier = Modifier.width(10.dp))
         Text(
-            text = name,
+            text = user.name,
             style = Typography.bodySmall,
             color = Black,
-            modifier = Modifier.fillMaxWidth().align(Alignment.CenterVertically),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.CenterVertically),
         )
     }
 }
@@ -45,5 +63,5 @@ fun UserItem(
 @Preview
 @Composable
 private fun UserItemPreview() {
-    UserItem(profileImage = "", name = "김서현", modifier = Modifier.fillMaxWidth())
+    UserLazyColumn(users = listOf(UserUiModel(1, "", "김민수"), UserUiModel(2, "", "신나라")))
 }

--- a/app/src/main/java/com/grusie/sharingmap/designsystem/component/UserItem.kt
+++ b/app/src/main/java/com/grusie/sharingmap/designsystem/component/UserItem.kt
@@ -1,0 +1,49 @@
+package com.grusie.sharingmap.designsystem.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.grusie.sharingmap.designsystem.theme.Black
+import com.grusie.sharingmap.designsystem.theme.Typography
+
+@Composable
+fun UserItem(
+    profileImage: String,
+    name: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier.padding(vertical = 8.dp, horizontal = 20.dp)) {
+        AsyncImage(
+            model = profileImage,
+            contentDescription = null,
+            modifier = Modifier
+                .size(32.dp)
+                .clip(RoundedCornerShape(8.dp)),
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Text(
+            text = name,
+            style = Typography.bodySmall,
+            color = Black,
+            modifier = Modifier.fillMaxWidth().align(Alignment.CenterVertically),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun UserItemPreview() {
+    UserItem(profileImage = "", name = "김서현", modifier = Modifier.fillMaxWidth())
+}

--- a/app/src/main/java/com/grusie/sharingmap/designsystem/theme/Color.kt
+++ b/app/src/main/java/com/grusie/sharingmap/designsystem/theme/Color.kt
@@ -13,3 +13,6 @@ val Gray300 = Color(0xFFBABBBC)
 val Gray400 = Color(0xFF9A9C9F)
 
 val Gray200_30 = Color(0x40E8EAEB)
+
+val GrayA8AAAB = Color(0xFFA8AAAB)
+val GrayE6E6E6 = Color(0xFFE6E6E6)

--- a/app/src/main/java/com/grusie/sharingmap/designsystem/theme/Type.kt
+++ b/app/src/main/java/com/grusie/sharingmap/designsystem/theme/Type.kt
@@ -3,150 +3,171 @@ package com.grusie.sharingmap.designsystem.theme
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
 import com.grusie.sharingmap.R
 
-val pretendard = FontFamily(
-    Font(R.font.pretendard_medium, FontWeight.Medium, FontStyle.Normal),
-    Font(R.font.pretendard_regular, FontWeight.Normal, FontStyle.Normal),
-    Font(R.font.pretendard_bold, FontWeight.Bold, FontStyle.Normal),
-    Font(R.font.pretendard_semibold, FontWeight.SemiBold, FontStyle.Normal),
-)
+val pretendard =
+    FontFamily(
+        Font(R.font.pretendard_medium, FontWeight.Medium, FontStyle.Normal),
+        Font(R.font.pretendard_regular, FontWeight.Normal, FontStyle.Normal),
+        Font(R.font.pretendard_bold, FontWeight.Bold, FontStyle.Normal),
+        Font(R.font.pretendard_semibold, FontWeight.SemiBold, FontStyle.Normal),
+    )
 
 // Set of Material typography styles to start with
-val Typography = Typography(
-    displayLarge = TextStyle(
-        fontFamily = pretendard,
-        fontSize = 32.sp,
-        fontWeight = FontWeight.SemiBold,
-        platformStyle = PlatformTextStyle(
-            includeFontPadding = false,
-        ),
-    ),
-    displayMedium = TextStyle(
-        fontFamily = pretendard,
-        fontSize = 18.sp,
-        fontWeight = FontWeight.Bold,
-        letterSpacing = (-0.1).sp,
-        platformStyle = PlatformTextStyle(
-            includeFontPadding = false,
-        ),
-    ),
-
-    headlineLarge = TextStyle(
-        fontFamily = pretendard,
-        fontSize = 16.sp,
-        fontWeight = FontWeight.Bold,
-        letterSpacing = (-0.2).sp,
-        platformStyle = PlatformTextStyle(
-            includeFontPadding = false,
-        ),
-    ),
-    headlineMedium =  TextStyle(
-        fontFamily = pretendard,
-        fontSize = 16.sp,
-        fontWeight = FontWeight.SemiBold,
-        letterSpacing = (-0.3).sp,
-        platformStyle = PlatformTextStyle(
-            includeFontPadding = false,
-        ),
-    ),
-
-    headlineSmall = TextStyle(
-        fontFamily = pretendard,
-        fontSize = 16.sp,
-        fontWeight = FontWeight.Normal,
-        platformStyle = PlatformTextStyle(
-            includeFontPadding = false,
-        ),
-    ),
-
-    titleLarge = TextStyle(
-        fontFamily = pretendard,
-        fontSize = 16.sp,
-        fontWeight = FontWeight.Medium,
-        letterSpacing = (-0.3).sp,
-        platformStyle = PlatformTextStyle(
-            includeFontPadding = false,
-        ),
-    ),
-    titleMedium = TextStyle(
-        fontFamily = pretendard,
-        fontSize = 14.sp,
-        fontWeight = FontWeight.SemiBold,
-        letterSpacing = (-0.2).sp,
-        platformStyle = PlatformTextStyle(
-            includeFontPadding = false,
-        ),
-    ),
-
-    titleSmall = TextStyle(
-        fontFamily = pretendard,
-        fontSize = 14.sp,
-        fontWeight = FontWeight.Medium,
-        platformStyle = PlatformTextStyle(
-            includeFontPadding = false,
-        ),
-    ),
-
-    bodyLarge = TextStyle(
-        fontFamily = pretendard,
-        fontSize = 14.sp,
-        fontWeight = FontWeight.Normal, // Regular
-        letterSpacing = (-0.1).sp,
-        platformStyle = PlatformTextStyle(
-            includeFontPadding = false,
-        ),
-    ),
-
-    bodyMedium = TextStyle(
-        fontFamily = pretendard,
-        fontSize = 13.sp,
-        fontWeight = FontWeight.Medium,
-        letterSpacing = (-0.3).sp,
-        platformStyle = PlatformTextStyle(
-            includeFontPadding = false,
-        ),
-    ),
-
-    bodySmall = TextStyle(
-        fontFamily = pretendard,
-        fontSize = 13.sp,
-        fontWeight = FontWeight.Medium,
-        letterSpacing = (-0.1).sp,
-        platformStyle = PlatformTextStyle(
-            includeFontPadding = false,
-        ),
-    ),
-    labelLarge = TextStyle(
-        fontFamily = pretendard,
-        fontSize = 12.sp,
-        fontWeight = FontWeight.Medium,
-        letterSpacing = (-0.2).sp,
-        platformStyle = PlatformTextStyle(
-            includeFontPadding = false,
-        ),
-    ),
-    labelMedium = TextStyle(
-        fontFamily = pretendard,
-        fontSize = 12.sp,
-        fontWeight = FontWeight.Normal, // Regular
-        letterSpacing = (-0.2).sp,
-        platformStyle = PlatformTextStyle(
-            includeFontPadding = false,
-        ),
-    ),
-
-    labelSmall = TextStyle(
-        fontFamily = pretendard,
-        fontSize = 12.sp,
-        fontWeight = FontWeight.Normal,
-        platformStyle = PlatformTextStyle(
-            includeFontPadding = false,
-        ),
-    ),
-)
+val Typography =
+    Typography(
+        displayLarge =
+            TextStyle(
+                fontFamily = pretendard,
+                fontSize = 32.sp,
+                fontWeight = FontWeight.SemiBold,
+                platformStyle =
+                    PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+            ),
+        displayMedium =
+            TextStyle(
+                fontFamily = pretendard,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = (-0.1).sp,
+                platformStyle =
+                    PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+            ),
+        headlineLarge =
+            TextStyle(
+                fontFamily = pretendard,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = (-0.2).sp,
+                platformStyle =
+                    PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+            ),
+        headlineMedium =
+            TextStyle(
+                fontFamily = pretendard,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = (-0.3).sp,
+                platformStyle =
+                    PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+            ),
+        headlineSmall =
+            TextStyle(
+                fontFamily = pretendard,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Normal,
+                platformStyle =
+                    PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+            ),
+        titleLarge =
+            TextStyle(
+                fontFamily = pretendard,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = (-0.3).sp,
+                platformStyle =
+                    PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+            ),
+        titleMedium =
+            TextStyle(
+                fontFamily = pretendard,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = (-0.2).sp,
+                platformStyle =
+                    PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+            ),
+        titleSmall =
+            TextStyle(
+                fontFamily = pretendard,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium,
+                platformStyle =
+                    PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+            ),
+        bodyLarge =
+            TextStyle(
+                fontFamily = pretendard,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Normal, // Regular
+                letterSpacing = (-0.1).sp,
+                platformStyle =
+                    PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+            ),
+        bodyMedium =
+            TextStyle(
+                fontFamily = pretendard,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Normal,
+                platformStyle =
+                    PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+            ),
+        bodySmall =
+            TextStyle(
+                fontFamily = pretendard,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = (-0.1).sp,
+                platformStyle =
+                    PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+            ),
+        labelLarge =
+            TextStyle(
+                fontFamily = pretendard,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = (-0.2).sp,
+                platformStyle =
+                    PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+            ),
+        labelMedium =
+            TextStyle(
+                fontFamily = pretendard,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Normal, // Regular
+                letterSpacing = (-0.2).sp,
+                platformStyle =
+                    PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+            ),
+        labelSmall =
+            TextStyle(
+                fontFamily = pretendard,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Normal,
+                platformStyle =
+                    PlatformTextStyle(
+                        includeFontPadding = false,
+                    ),
+            ),
+    )

--- a/app/src/main/java/com/grusie/sharingmap/ui/model/CommentUiModel.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/model/CommentUiModel.kt
@@ -1,0 +1,10 @@
+package com.grusie.sharingmap.ui.model
+
+import java.time.LocalDate
+
+data class CommentUiModel(
+    val id: Long,
+    val user: UserUiModel,
+    val date: LocalDate,
+    val content: String,
+)

--- a/app/src/main/java/com/grusie/sharingmap/ui/model/FeedUiModel.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/model/FeedUiModel.kt
@@ -1,8 +1,7 @@
 package com.grusie.sharingmap.ui.model
 
 data class FeedUiModel(
-    val profileImage: String,
-    val title: String,
+    val user: UserUiModel,
     val date: String,
     val content: String,
     val contentImages: List<String>,

--- a/app/src/main/java/com/grusie/sharingmap/ui/model/UserUiModel.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/model/UserUiModel.kt
@@ -1,0 +1,7 @@
+package com.grusie.sharingmap.ui.model
+
+data class UserUiModel(
+    val id: Long,
+    val profileImage: String,
+    val name: String,
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,5 +13,6 @@
     <string name="feed_modal_unfollow_title">팔로우 취소</string>
     <string name="feed_modal_declaration_title">신고</string>
     <string name="feed_modal_declaration_description">해당 유저 게시물 노출이 제한됩니다.</string>
+    <string name="feed_bottom_sheet_comment_hint_title">입력...</string>
 
 </resources>


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #15 

## 📝 작업 요약

피드 바텀 시트 구현

## 🔎 작업 상세 설명

피드 바텀 시트 modalbottomsheet를 사용해서 구현
피드 바텀 시트에 들어갈 아카이빙 리스트와 아카이빙 아이템 컴포넌트 구현, 댓글 리스트와 댓글 아이템, 댓글 입력 컴포넌트 구현
