### PR TITLE
refactor: 검색 스크린 수정

### DIFF
--- a/app/src/main/java/com/grusie/sharingmap/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/MainActivity.kt
@@ -27,6 +27,7 @@ class MainActivity : ComponentActivity() {
             val currentDestination = navBackStackEntry?.destination?.route
             val isBottomBarVisible = when {
                 currentDestination?.startsWith(NavItem.Storage.screenRoute) == true -> false
+                currentDestination?.equals(MainBottomNavItem.Search.screenRoute) == true -> false
                 else -> true
             }
             SharingMapTheme {

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchScreen.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -13,10 +15,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
 import com.grusie.sharingmap.R
 import com.grusie.sharingmap.designsystem.component.CustomTab
 import com.grusie.sharingmap.designsystem.theme.Typography
@@ -26,7 +30,7 @@ import com.grusie.sharingmap.ui.model.SearchTab
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
-fun SearchScreen(viewModel: SearchViewModel = hiltViewModel()) {
+fun SearchScreen(viewModel: SearchViewModel = hiltViewModel(), navController: NavController) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Scaffold(
@@ -44,6 +48,11 @@ fun SearchScreen(viewModel: SearchViewModel = hiltViewModel()) {
                     containerColor = White,
                     scrolledContainerColor = White,
                 ),
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(painter = painterResource(id = R.drawable.btn_back), contentDescription = null)
+                    }
+                }
             )
         },
         content = {
@@ -68,10 +77,4 @@ fun SearchScreen(viewModel: SearchViewModel = hiltViewModel()) {
             }
         }
     )
-}
-
-@Preview
-@Composable
-private fun SearchScreenPreview() {
-    SearchScreen()
 }

--- a/app/src/main/java/com/grusie/sharingmap/ui/navigation/main/MainBottomNavGraph.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/navigation/main/MainBottomNavGraph.kt
@@ -29,7 +29,7 @@ fun MainBottomNavGraph(navController: NavHostController, onBackPressed: () -> Un
             EditScreen()
         }
         composable(MainBottomNavItem.Search.screenRoute) {
-            SearchScreen()
+            SearchScreen(navController = navController)
         }
         composable(MainBottomNavItem.MyPage.screenRoute) {
             MyPageScreen(navController = navController)


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #27 

## 📝 작업 요약

검색 스크린 수정

## 🔎 작업 상세 설명

바텀 네비게이션 클릭 시 검색 페이지가 전체 화면을 차지하게 수정
뒤로가기 버튼 클릭 시 이전 네이개이션으로 이동하게 수정

SearchScreen에 NavController연결해서 뒤로가기 버튼 클릭 시 이전 네비게이션으로 이동하도록 수정
현재 네비게이션의 위치가 Search 스크린이라면 바텀 bar가 보이지 않도록 분기 처리 추가
