### PR TITLE
feat: 더보기, 접기 추가해서 클릭시 확장 및 축소가 가능하도록 기능 구현

### DIFF
--- a/app/src/main/java/com/grusie/sharingmap/designsystem/component/LimitedText.kt
+++ b/app/src/main/java/com/grusie/sharingmap/designsystem/component/LimitedText.kt
@@ -2,18 +2,29 @@ package com.grusie.sharingmap.designsystem.component
 
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
 import com.grusie.sharingmap.designsystem.theme.Black
 import com.grusie.sharingmap.designsystem.theme.GrayA8AAAB
 import com.grusie.sharingmap.designsystem.theme.Typography
 
 @Composable
-fun LimitedText(text: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+fun LimitedText(
+    text: String,
+    isExpanded: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+
     val displayText = if (text.length > 50) {
-        text.substring(0, 50) + "..."
+        if (isExpanded) text else text.substring(0, 50) + "..."
     } else {
         text
     }
@@ -24,16 +35,36 @@ fun LimitedText(text: String, onClick: () -> Unit, modifier: Modifier = Modifier
         }
         if (text.length > 50) {
             withStyle(style = SpanStyle(color = GrayA8AAAB)) {
-                append(" 더보기")
+                val startIndex = length
+                append(if (isExpanded) "  접기" else "  더보기")
+                addStringAnnotation(
+                    tag = if (isExpanded) "접기" else "더보기",
+                    annotation = "",
+                    start = startIndex,
+                    end = length
+                )
             }
         }
     }
 
     ClickableText(text = annotatedString, onClick = { offset ->
-        annotatedString.getStringAnnotations(tag = "더보기", start = offset, end = offset)
-            .firstOrNull()?.let {
-                onClick()
-            }
+        annotatedString.getStringAnnotations(
+            start = offset,
+            end = offset
+        ).firstOrNull()?.let {
+            onClick()
+        }
     }, style = Typography.bodyMedium, modifier = modifier)
+
+}
+
+@Preview
+@Composable
+private fun LimitedTextPreview() {
+    var isExpanded by remember { mutableStateOf(false) }
+    LimitedText(
+        text = "안녕하세요. 김민수입니다. 잘 부탁드립니다. 안녕하세요. 김민수입니다. 잘 부탁드립니다. 안녕하세요. 김민수입니다. 잘 부탁드립니다. 안녕하세요. 김민수입니다. 잘 부탁드립니다",
+        isExpanded = isExpanded,
+        onClick = { isExpanded = !isExpanded })
 
 }

--- a/app/src/main/java/com/grusie/sharingmap/designsystem/component/User.kt
+++ b/app/src/main/java/com/grusie/sharingmap/designsystem/component/User.kt
@@ -17,12 +17,16 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -142,9 +146,15 @@ fun UserItemWithCount(user: UserUiModel, modifier: Modifier = Modifier) {
 
 @Composable
 fun UserInfo(user: UserUiModel, modifier: Modifier = Modifier) {
+    var isExpanded by rememberSaveable { mutableStateOf(false) }
     Column {
         UserItemWithCount(user)
-        LimitedText(text = user.description, onClick = { /*TODO*/ }, modifier = modifier.padding(16.dp))
+        LimitedText(
+            text = user.description,
+            isExpanded = isExpanded,
+            onClick = { isExpanded = !isExpanded },
+            modifier = modifier.padding(16.dp)
+        )
     }
 
 }


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #32 

## 📝 작업 요약

텍스트 더보기, 접기 기능 추가

## 🔎 작업 상세 설명

텍스트 길이가 50 이상일 때는 텍스트를 자른 후 더보기를 붙임.
더보기를 클릭시 텍스트 전체를 볼 수 있고 접기 텍스트가 추가로 붙음.
접기를 클릭하면 이전 상태로 돌아가도록 구현.
