### PR TITLE
refactor: UI state 방법 수정 및 테스트 코드 작성

### DIFF
--- a/app/src/androidTest/java/com/grusie/sharingmap/BaseTest.kt
+++ b/app/src/androidTest/java/com/grusie/sharingmap/BaseTest.kt
@@ -1,0 +1,9 @@
+package com.grusie.sharingmap
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import org.junit.Rule
+
+open class BaseTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+}

--- a/app/src/androidTest/java/com/grusie/sharingmap/ui/screen/mypage/MyPageScreenTest.kt
+++ b/app/src/androidTest/java/com/grusie/sharingmap/ui/screen/mypage/MyPageScreenTest.kt
@@ -1,0 +1,92 @@
+package com.grusie.sharingmap.ui.screen.mypage
+
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.isNotDisplayed
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import com.grusie.sharingmap.BaseTest
+import com.grusie.sharingmap.R
+import com.grusie.sharingmap.ui.main.mypage.MyPageScreen
+import com.grusie.sharingmap.ui.main.mypage.MyPageUiState
+import com.grusie.sharingmap.ui.model.UserUiModel
+import org.junit.Before
+import org.junit.Test
+
+class MyPageScreenTest : BaseTest() {
+
+    private var state = mutableStateOf(MyPageUiState())
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            MyPageScreen(
+                uiState = state.value,
+                snackbarHostState = SnackbarHostState(),
+                updateSelectedTabIndex = {},
+                updateIsStorageBottomSheetOpen = {},
+                onUserClick = {},
+                onStorageClick = {})
+        }
+    }
+
+    @Test
+    fun 화면에_유저_이름이_두번_보여진다() {
+        state.value = MyPageUiState(user = UserUiModel(name = "김민수"))
+
+        val nodes = composeTestRule.onAllNodesWithText("김민수").fetchSemanticsNodes()
+        assert(nodes.size == 2)
+
+        composeTestRule.onAllNodesWithText("김민수")[0].assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("김민수")[1].assertIsDisplayed()
+    }
+
+    @Test
+    fun 유저_설명이_50글자를_초과하면_유저_설명이_50글자로_제한되고_말줄임표시와_함께_더보기_글자가_활성화된다() {
+        state.value = MyPageUiState(user = UserUiModel(description = "안녕하세요. 김민수입니다. 잘 부탁드립니다. 안녕하세요. 김민수입니다. 잘 부탁드립니다."))
+
+        composeTestRule.onNodeWithText("안녕하세요. 김민수입니다. 잘 부탁드립니다. 안녕하세요. 김민수입니다. 잘 부탁드...").isDisplayed()
+        composeTestRule.onNodeWithText("더보기").isDisplayed()
+    }
+
+    @Test
+    fun 유저_설명이_50글자를_초과하고_더보기_글자를_클릭하면_유저_설명이_전체가_보이고_접기_글자가_활성화된다() {
+        state.value = MyPageUiState(user = UserUiModel(description = "안녕하세요. 김민수입니다. 잘 부탁드립니다. 안녕하세요. 김민수입니다. 잘 부탁드립니다."))
+
+        // 더보기 글자가 보이고 클릭
+        composeTestRule.onNodeWithText("더보기").isDisplayed()
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.mypage_limited_text_button)).performClick()
+
+        composeTestRule.onNodeWithText("안녕하세요. 김민수입니다. 잘 부탁드립니다. 안녕하세요. 김민수입니다. 잘 부탁드립니다.").isDisplayed()
+        composeTestRule.onNodeWithText("접기").isDisplayed()
+        composeTestRule.onNodeWithText("더보기").isNotDisplayed()
+    }
+
+    @Test
+    fun 로딩_상태에서_로딩_프로그레스가_보여진다() {
+        state.value = MyPageUiState(isLoading = true)
+
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.loading_prgress)).isDisplayed()
+    }
+
+    @Test
+    fun 로딩_상태가_아니라면_로딩_프로그레스가_보이지않아야_한다() {
+        state.value = MyPageUiState(isLoading = false)
+
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.loading_prgress)).isNotDisplayed()
+    }
+
+    @Test
+    fun 에러가_발생하면_스낵바에_에러문구가_보여진다() {
+        state.value = MyPageUiState(errorMessage = "에러가 발생했습니다.")
+        composeTestRule.onNodeWithText("에러가 발생했습니다.").isDisplayed()
+    }
+
+}

--- a/app/src/androidTest/java/com/grusie/sharingmap/ui/screen/search/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/grusie/sharingmap/ui/screen/search/SearchScreenTest.kt
@@ -1,0 +1,118 @@
+package com.grusie.sharingmap.ui.screen.search
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.text2.input.TextFieldState
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import com.grusie.sharingmap.BaseTest
+import com.grusie.sharingmap.ui.main.search.SearchScreen
+import com.grusie.sharingmap.ui.main.search.SearchUiState
+import com.grusie.sharingmap.ui.model.TagUiModel
+import com.grusie.sharingmap.ui.model.UserUiModel
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalFoundationApi::class)
+class SearchScreenTest : BaseTest() {
+
+    private var state = mutableStateOf(SearchUiState())
+    private val fakeUserData = listOf(
+        UserUiModel(
+            id = 1L,
+            profileImage = "",
+            name = "이하은",
+            description = "안녕하세요, 반갑습니다",
+            email = "",
+            followerCount = 50,
+            postCount = 20,
+            follow = false
+        ),
+        UserUiModel(
+            id = 2L,
+            profileImage = "",
+            name = "이하영",
+            description = "안녕하세요, 반갑습니다2",
+            email = "",
+            followerCount = 50,
+            postCount = 20,
+            follow = false
+        )
+    )
+
+    private val fakeTagData = listOf(
+        TagUiModel(
+            id = 1L,
+            name = "식당",
+            count = 30,
+        ),
+        TagUiModel(
+            id = 2L,
+            name = "식품관",
+            count = 30,
+        )
+    )
+
+    @Before
+    fun setUp() {
+        state.value = SearchUiState(userSearch = fakeUserData, tagSearch = fakeTagData)
+        composeTestRule.setContent {
+            SearchScreen(
+                uiState = state.value,
+                snackbarHostState = SnackbarHostState(),
+                searchTextField = TextFieldState(),
+                updateSelectedTabIndex = {},
+                insertUserSearchHistory = {},
+                insertTagSearchHistory = {},
+                deleteAllUerSearchHistory = { /*TODO*/ },
+                deleteAllTagSearchHistory = { /*TODO*/ },
+                onNavigationClick = { /*TODO*/ },
+                onUserItemClick = {},
+                onTagItemClick = {}
+            )
+        }
+
+    }
+
+    @Test
+    fun 탭이_사람으로_되어있고_입력된_텍스트가_없으면_유저_검색_기록만_노출된다() {
+        state.value = state.value.copy(searchTextField = TextFieldState(initialText = ""), selectedTabIndex = 0)
+        composeTestRule.onNodeWithText("이하은").assertIsDisplayed()
+        composeTestRule.onNodeWithText("이하영").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("식당 +30").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("식품관 +30").assertIsNotDisplayed()
+    }
+
+    @Test
+    fun 탭이_사람으로_되어있고_입력된_텍스트가_있으면_유저_검색_결과만_노출된다() {
+        state.value = state.value.copy(searchTextField = TextFieldState(initialText = "이"), selectedTabIndex = 0)
+        composeTestRule.onNodeWithText("이하은").assertIsDisplayed()
+        composeTestRule.onNodeWithText("이하영").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("식당 +30").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("식품관 +30").assertIsNotDisplayed()
+    }
+
+    @Test
+    fun 탭이_태그로_되어있고_입력된_텍스트가_없으면_태그_검색_기록만_노출된다() {
+        state.value = state.value.copy(searchTextField = TextFieldState(initialText = ""), selectedTabIndex = 1)
+        composeTestRule.onNodeWithText("식당 +30").assertIsDisplayed()
+        composeTestRule.onNodeWithText("식품관 +30").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("이하은").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("이하영").assertIsNotDisplayed()
+    }
+
+    @Test
+    fun 탭이_태그로_되어있고_입력된_텍스트가_없으면_태그_검색_결과만_노출된다() {
+        state.value = state.value.copy(searchTextField = TextFieldState(initialText = "식"), selectedTabIndex = 1)
+        composeTestRule.onNodeWithText("식당 +30").assertIsDisplayed()
+        composeTestRule.onNodeWithText("식품관 +30").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("이하은").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("이하영").assertIsNotDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/grusie/sharingmap/ui/screen/search/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/grusie/sharingmap/ui/screen/search/SearchScreenTest.kt
@@ -18,7 +18,6 @@ import org.junit.Test
 @OptIn(ExperimentalFoundationApi::class)
 class SearchScreenTest : BaseTest() {
 
-    private var state = mutableStateOf(SearchUiState())
     private val fakeUserData = listOf(
         UserUiModel(
             id = 1L,
@@ -54,10 +53,10 @@ class SearchScreenTest : BaseTest() {
             count = 30,
         )
     )
+    private var state = mutableStateOf(SearchUiState(userSearch = fakeUserData, tagSearch = fakeTagData))
 
     @Before
     fun setUp() {
-        state.value = SearchUiState(userSearch = fakeUserData, tagSearch = fakeTagData)
         composeTestRule.setContent {
             SearchScreen(
                 uiState = state.value,
@@ -115,4 +114,11 @@ class SearchScreenTest : BaseTest() {
         composeTestRule.onNodeWithText("이하은").assertIsNotDisplayed()
         composeTestRule.onNodeWithText("이하영").assertIsNotDisplayed()
     }
+
+   /* @Test
+    fun 에러가_발생하면_에러문구를_스낵바에_보여준다() {
+        state.value = SearchUiState(errorMessage = "에러가 발생했습니다.")
+
+        composeTestRule.onNodeWithText("에러가 발생했습니다.").assertIsDisplayed()
+    }*/
 }

--- a/app/src/main/java/com/grusie/sharingmap/designsystem/component/Feed.kt
+++ b/app/src/main/java/com/grusie/sharingmap/designsystem/component/Feed.kt
@@ -54,7 +54,7 @@ import com.grusie.sharingmap.ui.model.UserUiModel
 fun Feed(
     feed: ArchiveUiModel,
     isFollow: Boolean,
-    onUserClick: (UserUiModel) -> Unit,
+    onUserClick: (Long) -> Unit,
     onProfileClick: () -> Unit,
     onImageClick: (String) -> Unit,
     onLocationClick: () -> Unit,
@@ -71,7 +71,7 @@ fun Feed(
                 Modifier
                     .fillMaxWidth()
                     .padding(14.dp).clickable {
-                        onUserClick(feed.user)
+                        onUserClick(feed.user.id)
                     },
         ) {
             ProfileImage(feed.user.profileImage, isFollow, onProfileClick)

--- a/app/src/main/java/com/grusie/sharingmap/designsystem/component/LimitedText.kt
+++ b/app/src/main/java/com/grusie/sharingmap/designsystem/component/LimitedText.kt
@@ -7,10 +7,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
+import com.grusie.sharingmap.R
 import com.grusie.sharingmap.designsystem.theme.Black
 import com.grusie.sharingmap.designsystem.theme.GrayA8AAAB
 import com.grusie.sharingmap.designsystem.theme.Typography
@@ -22,6 +26,8 @@ fun LimitedText(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+
+    val context = LocalContext.current
 
     val displayText = if (text.length > 50) {
         if (isExpanded) text else text.substring(0, 50) + "..."
@@ -54,7 +60,11 @@ fun LimitedText(
         ).firstOrNull()?.let {
             onClick()
         }
-    }, style = Typography.bodyMedium, modifier = modifier)
+    }, style = Typography.bodyMedium, modifier = modifier.semantics {
+        contentDescription = context.getString(
+            R.string.mypage_limited_text_button
+        )
+    })
 
 }
 

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/MyPageScreen.kt
@@ -52,7 +52,7 @@ import com.grusie.sharingmap.ui.model.UserUiModel
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun MyPageRoute(
-    onUserClick: (UserUiModel) -> Unit,
+    onUserClick: (Long) -> Unit,
     onStorageClick: (StorageUiModel) -> Unit,
     viewModel: MyPageViewModel = hiltViewModel()
 ) {
@@ -100,7 +100,7 @@ fun MyPageScreen(
     snackbarHostState: SnackbarHostState,
     updateSelectedTabIndex: (Int) -> Unit,
     updateIsStorageBottomSheetOpen: (Boolean) -> Unit,
-    onUserClick: (UserUiModel) -> Unit,
+    onUserClick: (Long) -> Unit,
     onStorageClick: (StorageUiModel) -> Unit,
 ) {
     val context = LocalContext.current

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/MyPageScreen.kt
@@ -59,10 +59,8 @@ fun MyPageScreen(viewModel: MyPageViewModel = hiltViewModel(), navController: Na
     )
     val snackbarHostState = remember { SnackbarHostState() }
 
-    LaunchedEffect(Unit) {
-        viewModel.errorMessage.collectLatest {
-            snackbarHostState.showSnackbar(it)
-        }
+    LaunchedEffect(uiState.errorMessage) {
+        if(uiState.errorMessage.isNotEmpty()) snackbarHostState.showSnackbar(uiState.errorMessage)
     }
 
     Scaffold(

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/MyPageScreen.kt
@@ -27,8 +27,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -100,6 +103,7 @@ fun MyPageScreen(
     onUserClick: (UserUiModel) -> Unit,
     onStorageClick: (StorageUiModel) -> Unit,
 ) {
+    val context = LocalContext.current
     Scaffold(
         modifier = Modifier
             .fillMaxSize()
@@ -128,7 +132,7 @@ fun MyPageScreen(
 
                     if (uiState.isLoading) {
                         Box(modifier = Modifier.fillMaxSize()) {
-                            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center).semantics { contentDescription =  context.getString(R.string.loading_prgress)})
                         }
                     } else {
                         if (uiState.selectedTabIndex == 0) {

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/MyPageUiState.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/MyPageUiState.kt
@@ -12,4 +12,5 @@ data class MyPageUiState(
     val selectedTabIndex: Int = 0,
     val isStorageBottomSheetOpen: Boolean = false,
     val isStorageLock: Boolean = false,
+    val errorMessage: String = ""
 )

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/MyPageUiState.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/MyPageUiState.kt
@@ -4,12 +4,12 @@ import com.grusie.sharingmap.ui.model.ArchiveUiModel
 import com.grusie.sharingmap.ui.model.StorageUiModel
 import com.grusie.sharingmap.ui.model.UserUiModel
 
-sealed interface MyPageUiState {
-    data object Loading: MyPageUiState
-    data class Success(
-        val user: UserUiModel = UserUiModel(),
-        val feeds: List<ArchiveUiModel> = emptyList(),
-        val storages: List<StorageUiModel> = emptyList()
-    ): MyPageUiState
-    data class Error(val message: String): MyPageUiState
-}
+data class MyPageUiState(
+    val isLoading: Boolean = false,
+    val user: UserUiModel? = null,
+    val feeds: List<ArchiveUiModel> = emptyList(),
+    val storages: List<StorageUiModel> = emptyList(),
+    val selectedTabIndex: Int = 0,
+    val isStorageBottomSheetOpen: Boolean = false,
+    val isStorageLock: Boolean = false,
+)

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/MyPageViewModel.kt
@@ -11,8 +11,11 @@ import com.gruise.domain.usecase.user.UserUseCase
 import com.grusie.sharingmap.ui.mapper.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -26,19 +29,18 @@ class MyPageViewModel @Inject constructor(
 ) : ViewModel() {
 
     val storageTitleTextField = TextFieldState()
-    private val _uiState = MutableStateFlow<MyPageUiState>(MyPageUiState.Loading)
+    private val _uiState = MutableStateFlow(MyPageUiState())
     val uiState: StateFlow<MyPageUiState> = _uiState.asStateFlow()
-    private val _selectedTabIndex = MutableStateFlow(0)
-    val selectedTabIndex: StateFlow<Int> = _selectedTabIndex.asStateFlow()
+    private val _errorMessage = MutableSharedFlow<String>()
+    val errorMessage: SharedFlow<String> = _errorMessage.asSharedFlow()
 
     init {
         getMyPageInfo()
     }
 
     private fun getMyPageInfo() {
+        _uiState.value = _uiState.value.copy(isLoading = true)
         viewModelScope.launch {
-            _uiState.value = MyPageUiState.Loading
-
             val myInfoDeferred = async { userUseCase.getMyInfoUseCase() }
             val storagesDeferred = async { storageUseCase.getStoragesUseCase() }
 
@@ -46,28 +48,38 @@ class MyPageViewModel @Inject constructor(
             val storages = storagesDeferred.await()
 
             if (myInfo.isSuccess) {
+                _uiState.value = _uiState.value.copy(user = myInfo.getOrNull()!!.toUiModel())
+
                 val myFeedDeferred =
-                    async { archiveUseCase.getArchivesByAuthorIdUseCase(myInfo.getOrNull()!!.userId) }
+                    async { archiveUseCase.getArchivesByAuthorIdUseCase(_uiState.value.user!!.id) }
 
                 val myFeed = myFeedDeferred.await()
-
                 if (myFeed.isSuccess && storages.isSuccess) {
-                    _uiState.value = MyPageUiState.Success(
-                        user = myInfo.getOrNull()!!.toUiModel(),
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
                         feeds = myFeed.getOrNull()!!.map { it.toUiModel() },
-                        storages = storages.getOrNull()!!.map { it.toUiModel() }
+                        storages = storages.getOrNull()!!.map { it.toUiModel() },
                     )
                 } else {
-                    _uiState.value = MyPageUiState.Error((myFeed.exceptionOrNull() as RemoteError).toStringForUser())
+                    _uiState.value = _uiState.value.copy(isLoading = false)
+                    _errorMessage.emit((myFeed.exceptionOrNull() as RemoteError).toStringForUser())
                 }
             } else {
-                _uiState.value = MyPageUiState.Error((myInfo.exceptionOrNull() as RemoteError).toStringForUser())
+                _uiState.value = _uiState.value.copy(isLoading = false)
+                _errorMessage.emit((myInfo.exceptionOrNull() as RemoteError).toStringForUser())
             }
         }
     }
 
     fun setSelectedTabIndex(index: Int) {
-        _selectedTabIndex.value = index
+        _uiState.value = _uiState.value.copy(selectedTabIndex = index)
     }
 
+    fun updateIsStorageBottomSheetOpen(isOpen: Boolean) {
+        _uiState.value = _uiState.value.copy(isStorageBottomSheetOpen = isOpen)
+    }
+
+    fun updateIsStorageLock() {
+        _uiState.value = _uiState.value.copy(isStorageLock = _uiState.value.isStorageLock.not())
+    }
 }

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/MyPageViewModel.kt
@@ -31,15 +31,15 @@ class MyPageViewModel @Inject constructor(
     val storageTitleTextField = TextFieldState()
     private val _uiState = MutableStateFlow(MyPageUiState())
     val uiState: StateFlow<MyPageUiState> = _uiState.asStateFlow()
-    private val _errorMessage = MutableSharedFlow<String>()
-    val errorMessage: SharedFlow<String> = _errorMessage.asSharedFlow()
+   /* private val _errorMessage = MutableSharedFlow<String>()
+    val errorMessage: SharedFlow<String> = _errorMessage.asSharedFlow()*/
 
     init {
         getMyPageInfo()
     }
 
     private fun getMyPageInfo() {
-        _uiState.value = _uiState.value.copy(isLoading = true)
+        _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = "")
         viewModelScope.launch {
             val myInfoDeferred = async { userUseCase.getMyInfoUseCase() }
             val storagesDeferred = async { storageUseCase.getStoragesUseCase() }
@@ -61,12 +61,10 @@ class MyPageViewModel @Inject constructor(
                         storages = storages.getOrNull()!!.map { it.toUiModel() },
                     )
                 } else {
-                    _uiState.value = _uiState.value.copy(isLoading = false)
-                    _errorMessage.emit((myFeed.exceptionOrNull() as RemoteError).toStringForUser())
+                    _uiState.value = _uiState.value.copy(isLoading = false, errorMessage = (myFeed.exceptionOrNull() as RemoteError).toStringForUser())
                 }
             } else {
-                _uiState.value = _uiState.value.copy(isLoading = false)
-                _errorMessage.emit((myInfo.exceptionOrNull() as RemoteError).toStringForUser())
+                _uiState.value = _uiState.value.copy(isLoading = false, errorMessage = (myInfo.exceptionOrNull() as RemoteError).toStringForUser())
             }
         }
     }

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/user/UserUiState.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/user/UserUiState.kt
@@ -5,9 +5,11 @@ import com.grusie.sharingmap.ui.model.StorageUiModel
 import com.grusie.sharingmap.ui.model.UserUiModel
 
 data class UserUiState(
+    val isLoading: Boolean = false,
     val user: UserUiModel = UserUiModel(),
     val selectedTabIndex: Int = 0,
     val isFollow: Boolean = false,
     val feeds: List<ArchiveUiModel> = emptyList(),
-    val storages: List<StorageUiModel> = emptyList()
+    val storages: List<StorageUiModel> = emptyList(),
+    val errorMessage: String = ""
 )

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/user/UserViewModel.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/mypage/user/UserViewModel.kt
@@ -1,29 +1,42 @@
 package com.grusie.sharingmap.ui.main.mypage.user
 
 import androidx.lifecycle.ViewModel
-import com.grusie.sharingmap.ui.model.UserUiModel
+import androidx.lifecycle.viewModelScope
+import com.gruise.data.remote.RemoteError
+import com.gruise.domain.usecase.user.UserUseCase
+import com.grusie.sharingmap.ui.mapper.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class UserViewModel @Inject constructor(): ViewModel() {
+class UserViewModel @Inject constructor(
+    private val userUseCase: UserUseCase,
+): ViewModel() {
     private val _uiState = MutableStateFlow(UserUiState())
     val uiState: StateFlow<UserUiState> = _uiState.asStateFlow()
 
-    fun setSelectedTabIndex(index: Int) {
+    fun updateSelectedTabIndex(index: Int) {
         _uiState.value = _uiState.value.copy(selectedTabIndex = index)
     }
 
-    fun updateUser(user: UserUiModel) {
-        _uiState.value = _uiState.value.copy(user = user)
+    fun getUser(userId: Long) {
+        _uiState.value = _uiState.value.copy(isLoading = true)
+        viewModelScope.launch {
+            userUseCase.getUserByUserIdUseCase(userId).onSuccess {
+                _uiState.value = _uiState.value.copy(user = it.toUiModel(), isLoading = false)
+            }.onFailure {
+                _uiState.value = _uiState.value.copy(isLoading = false, errorMessage = (it.message as RemoteError).toStringForUser())
+            }
+        }
     }
 
 
-    fun setIsFollow(isFollow: Boolean) {
-        _uiState.value = _uiState.value.copy(isFollow = isFollow)
+    fun updateIsFollow() {
+        _uiState.value = _uiState.value.copy(isFollow = !_uiState.value.isFollow)
     }
 
 }

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchContent.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchContent.kt
@@ -1,6 +1,5 @@
 package com.grusie.sharingmap.ui.main.search
 
-import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -46,7 +45,7 @@ fun SearchContent(
     SearchContentItem(
         selectedTabIndex = selectedTabIndex,
         lazyColumn = {
-            if(uiState.isLoading) {
+            if (uiState.isLoading) {
 
             } else {
                 if (selectedTabIndex == 0) UserLazyColumn(

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchContent.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchContent.kt
@@ -46,29 +46,21 @@ fun SearchContent(
     SearchContentItem(
         selectedTabIndex = selectedTabIndex,
         lazyColumn = {
-            when (uiState) {
-                is SearchUiState.SearchSuccess -> {
-                    if (selectedTabIndex == 0) UserLazyColumn(
-                        users = uiState.userSearch,
-                        isBottomSheet = true,
+            if(uiState.isLoading) {
+
+            } else {
+                if (selectedTabIndex == 0) UserLazyColumn(
+                    users = uiState.userSearch,
+                    isBottomSheet = true,
+                    modifier = Modifier.fillMaxHeight(),
+                    onClick = onUserItemClick,
+                ) else {
+                    TagLazyColumn(
+                        tags = uiState.tagSearch,
                         modifier = Modifier.fillMaxHeight(),
-                        onClick = onUserItemClick,
-                    ) else {
-                        TagLazyColumn(
-                            tags = uiState.tagSearch,
-                            modifier = Modifier.fillMaxHeight(),
-                            onClick = onTagItemClick
-                        )
-                    }
+                        onClick = onTagItemClick
+                    )
                 }
-                is SearchUiState.Loading -> {
-
-                }
-
-                is SearchUiState.Error -> {
-
-                }
-
             }
         },
         onUserHistoryDelete = onUserHistoryDelete,

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchScreen.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchScreen.kt
@@ -1,8 +1,8 @@
 package com.grusie.sharingmap.ui.main.search
 
 import android.annotation.SuppressLint
-import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -10,32 +10,46 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.google.gson.Gson
 import com.grusie.sharingmap.R
 import com.grusie.sharingmap.designsystem.component.CustomTab
+import com.grusie.sharingmap.designsystem.component.Snackbar
 import com.grusie.sharingmap.designsystem.theme.Black
 import com.grusie.sharingmap.designsystem.theme.Typography
 import com.grusie.sharingmap.designsystem.theme.White
 import com.grusie.sharingmap.ui.model.SearchTab
 import com.grusie.sharingmap.ui.navigation.main.NavItem
+import kotlinx.coroutines.flow.collectLatest
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun SearchScreen(viewModel: SearchViewModel = hiltViewModel(), navController: NavController) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val selectedTabIndex by viewModel.selectedTabIndex.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(Unit) {
+        viewModel.errorMessage.collectLatest {
+            snackbarHostState.showSnackbar(it)
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -64,38 +78,51 @@ fun SearchScreen(viewModel: SearchViewModel = hiltViewModel(), navController: Na
             )
         },
         content = {
-            Column(modifier = Modifier.padding(it)) {
-                CustomTab(
-                    selectedTabIndex = selectedTabIndex,
-                    onClick = { viewModel.setSelectedTabIndex(it) },
-                    tabs = SearchTab.entries.map { it.title })
-                SearchContent(
-                    selectedTabIndex = selectedTabIndex,
-                    uiState = uiState,
-                    searchText = viewModel.searchTextField,
-                    onUserItemClick = {
-                        viewModel.insertUserSearchHistory(it)
-                        navController.navigate(
-                            NavItem.User.screenRoute + "?user=${
-                                Gson().toJson(
-                                    it
-                                )
-                            }"
-                        )
-                    },
-                    onUserHistoryDelete = viewModel::deleteAllUserSearchHistory,
-                    onTagItemClick = {
-                        viewModel.insertTagSearchHistory(it)
-                        navController.navigate(
-                            NavItem.FeedCollection.screenRoute + "?tag=${
-                                Gson().toJson(
-                                    it
-                                )
-                            }"
-                        )
-                    },
-                    onTagHistoryDelete = viewModel::deleteAllTagSearchHistory
+            Box(modifier = Modifier.padding(it)) {
+                Column {
+                    CustomTab(
+                        selectedTabIndex = uiState.selectedTabIndex,
+                        onClick = { viewModel.setSelectedTabIndex(it) },
+                        tabs = SearchTab.entries.map { it.title })
+                    SearchContent(
+                        selectedTabIndex = uiState.selectedTabIndex,
+                        uiState = uiState,
+                        searchText = viewModel.searchTextField,
+                        onUserItemClick = {
+                            viewModel.insertUserSearchHistory(it)
+                            navController.navigate(
+                                NavItem.User.screenRoute + "?user=${
+                                    Gson().toJson(
+                                        it
+                                    )
+                                }"
+                            )
+                        },
+                        onUserHistoryDelete = viewModel::deleteAllUserSearchHistory,
+                        onTagItemClick = {
+                            viewModel.insertTagSearchHistory(it)
+                            navController.navigate(
+                                NavItem.FeedCollection.screenRoute + "?tag=${
+                                    Gson().toJson(
+                                        it
+                                    )
+                                }"
+                            )
+                        },
+                        onTagHistoryDelete = viewModel::deleteAllTagSearchHistory
+                    )
+                }
+
+                SnackbarHost(
+                    hostState = snackbarHostState,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 10.dp),
+                    snackbar = {
+                        Snackbar(data = it)
+                    }
                 )
+
             }
         }
     )

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchScreen.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchScreen.kt
@@ -45,7 +45,7 @@ import com.grusie.sharingmap.ui.navigation.main.NavItem
 fun SearchRoute(
     viewModel: SearchViewModel = hiltViewModel(),
     onNavigationClick: () -> Unit,
-    onUserItemClick: (UserUiModel) -> Unit,
+    onUserItemClick: (Long) -> Unit,
     onTagItemClick: (TagUiModel) -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -85,7 +85,7 @@ fun SearchScreen(
     deleteAllUerSearchHistory: () -> Unit,
     deleteAllTagSearchHistory: () -> Unit,
     onNavigationClick: () -> Unit,
-    onUserItemClick: (UserUiModel) -> Unit,
+    onUserItemClick: (Long) -> Unit,
     onTagItemClick: (TagUiModel) -> Unit
 ) {
 
@@ -128,7 +128,7 @@ fun SearchScreen(
                         searchText = searchTextField,
                         onUserItemClick = {
                             insertUserSearchHistory(it)
-                            onUserItemClick(it)
+                            onUserItemClick(it.id)
                         },
                         onUserHistoryDelete = deleteAllUerSearchHistory,
                         onTagItemClick = {

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchScreen.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchScreen.kt
@@ -60,7 +60,7 @@ fun SearchRoute(
     SearchScreen(
         uiState = uiState,
         snackbarHostState = snackbarHostState,
-        searchTextField = viewModel.searchTextField,
+        searchTextField = uiState.searchTextField,
         updateSelectedTabIndex = viewModel::setSelectedTabIndex,
         insertUserSearchHistory = viewModel::insertUserSearchHistory,
         insertTagSearchHistory = viewModel::insertTagSearchHistory,

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchScreen.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchScreen.kt
@@ -45,9 +45,9 @@ fun SearchScreen(viewModel: SearchViewModel = hiltViewModel(), navController: Na
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    LaunchedEffect(Unit) {
-        viewModel.errorMessage.collectLatest {
-            snackbarHostState.showSnackbar(it)
+    LaunchedEffect(uiState.errorMessage) {
+        if(uiState.errorMessage.isNotEmpty()) {
+            snackbarHostState.showSnackbar(uiState.errorMessage)
         }
     }
 

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchScreen.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text2.input.TextFieldState
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -23,10 +24,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavController
 import com.google.gson.Gson
 import com.grusie.sharingmap.R
 import com.grusie.sharingmap.designsystem.component.CustomTab
@@ -35,21 +36,58 @@ import com.grusie.sharingmap.designsystem.theme.Black
 import com.grusie.sharingmap.designsystem.theme.Typography
 import com.grusie.sharingmap.designsystem.theme.White
 import com.grusie.sharingmap.ui.model.SearchTab
+import com.grusie.sharingmap.ui.model.TagUiModel
+import com.grusie.sharingmap.ui.model.UserUiModel
 import com.grusie.sharingmap.ui.navigation.main.NavItem
-import kotlinx.coroutines.flow.collectLatest
 
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun SearchScreen(viewModel: SearchViewModel = hiltViewModel(), navController: NavController) {
+fun SearchRoute(
+    viewModel: SearchViewModel = hiltViewModel(),
+    onNavigationClick: () -> Unit,
+    onUserItemClick: (UserUiModel) -> Unit,
+    onTagItemClick: (TagUiModel) -> Unit
+) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(uiState.errorMessage) {
-        if(uiState.errorMessage.isNotEmpty()) {
+        if (uiState.errorMessage.isNotEmpty()) {
             snackbarHostState.showSnackbar(uiState.errorMessage)
         }
     }
+
+    SearchScreen(
+        uiState = uiState,
+        snackbarHostState = snackbarHostState,
+        searchTextField = viewModel.searchTextField,
+        updateSelectedTabIndex = viewModel::setSelectedTabIndex,
+        insertUserSearchHistory = viewModel::insertUserSearchHistory,
+        insertTagSearchHistory = viewModel::insertTagSearchHistory,
+        deleteAllUerSearchHistory = viewModel::deleteAllUserSearchHistory,
+        deleteAllTagSearchHistory = viewModel::deleteAllTagSearchHistory,
+        onNavigationClick = onNavigationClick,
+        onUserItemClick = onUserItemClick,
+        onTagItemClick = onTagItemClick
+    )
+}
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun SearchScreen(
+    uiState: SearchUiState,
+    snackbarHostState: SnackbarHostState,
+    searchTextField: TextFieldState,
+    updateSelectedTabIndex: (Int) -> Unit,
+    insertUserSearchHistory: (UserUiModel) -> Unit,
+    insertTagSearchHistory: (TagUiModel) -> Unit,
+    deleteAllUerSearchHistory: () -> Unit,
+    deleteAllTagSearchHistory: () -> Unit,
+    onNavigationClick: () -> Unit,
+    onUserItemClick: (UserUiModel) -> Unit,
+    onTagItemClick: (TagUiModel) -> Unit
+) {
 
     Scaffold(
         topBar = {
@@ -67,7 +105,7 @@ fun SearchScreen(viewModel: SearchViewModel = hiltViewModel(), navController: Na
                     scrolledContainerColor = White,
                 ),
                 navigationIcon = {
-                    IconButton(onClick = { navController.popBackStack() }) {
+                    IconButton(onClick = onNavigationClick) {
                         Icon(
                             painter = painterResource(id = R.drawable.btn_back),
                             tint = Black,
@@ -82,34 +120,22 @@ fun SearchScreen(viewModel: SearchViewModel = hiltViewModel(), navController: Na
                 Column {
                     CustomTab(
                         selectedTabIndex = uiState.selectedTabIndex,
-                        onClick = { viewModel.setSelectedTabIndex(it) },
+                        onClick = updateSelectedTabIndex,
                         tabs = SearchTab.entries.map { it.title })
                     SearchContent(
                         selectedTabIndex = uiState.selectedTabIndex,
                         uiState = uiState,
-                        searchText = viewModel.searchTextField,
+                        searchText = searchTextField,
                         onUserItemClick = {
-                            viewModel.insertUserSearchHistory(it)
-                            navController.navigate(
-                                NavItem.User.screenRoute + "?user=${
-                                    Gson().toJson(
-                                        it
-                                    )
-                                }"
-                            )
+                            insertUserSearchHistory(it)
+                            onUserItemClick(it)
                         },
-                        onUserHistoryDelete = viewModel::deleteAllUserSearchHistory,
+                        onUserHistoryDelete = deleteAllUerSearchHistory,
                         onTagItemClick = {
-                            viewModel.insertTagSearchHistory(it)
-                            navController.navigate(
-                                NavItem.FeedCollection.screenRoute + "?tag=${
-                                    Gson().toJson(
-                                        it
-                                    )
-                                }"
-                            )
+                            insertTagSearchHistory(it)
+                            onTagItemClick(it)
                         },
-                        onTagHistoryDelete = viewModel::deleteAllTagSearchHistory
+                        onTagHistoryDelete = deleteAllTagSearchHistory,
                     )
                 }
 
@@ -125,5 +151,24 @@ fun SearchScreen(viewModel: SearchViewModel = hiltViewModel(), navController: Na
 
             }
         }
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Preview
+@Composable
+fun SearchScreenPreview(modifier: Modifier = Modifier) {
+    SearchScreen(
+        uiState = SearchUiState(),
+        snackbarHostState = SnackbarHostState(),
+        searchTextField = TextFieldState(),
+        updateSelectedTabIndex =  {},
+        insertUserSearchHistory = {},
+        insertTagSearchHistory = {},
+        deleteAllUerSearchHistory = { /*TODO*/ },
+        deleteAllTagSearchHistory = { /*TODO*/ },
+        onNavigationClick = { /*TODO*/ },
+        onUserItemClick = {},
+        onTagItemClick = {}
     )
 }

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchUiState.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchUiState.kt
@@ -4,12 +4,9 @@ import com.grusie.sharingmap.ui.model.TagUiModel
 import com.grusie.sharingmap.ui.model.UserUiModel
 
 
-sealed interface SearchUiState {
-    data object Loading : SearchUiState
-    data class SearchSuccess(
-        val userSearch: List<UserUiModel> = emptyList(),
-        val tagSearch: List<TagUiModel> = emptyList(),
-    ) : SearchUiState
-
-    data class Error(val message: String) : SearchUiState
-}
+data class SearchUiState(
+    val isLoading: Boolean = false,
+    val userSearch: List<UserUiModel> = emptyList(),
+    val tagSearch: List<TagUiModel> = emptyList(),
+    val selectedTabIndex: Int = 0,
+)

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchUiState.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchUiState.kt
@@ -1,11 +1,13 @@
 package com.grusie.sharingmap.ui.main.search
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.text2.input.TextFieldState
 import com.grusie.sharingmap.ui.model.TagUiModel
 import com.grusie.sharingmap.ui.model.UserUiModel
 
-
-data class SearchUiState(
+data class SearchUiState @OptIn(ExperimentalFoundationApi::class) constructor(
     val isLoading: Boolean = false,
+    val searchTextField: TextFieldState = TextFieldState(),
     val userSearch: List<UserUiModel> = emptyList(),
     val tagSearch: List<TagUiModel> = emptyList(),
     val selectedTabIndex: Int = 0,

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchUiState.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchUiState.kt
@@ -9,4 +9,5 @@ data class SearchUiState(
     val userSearch: List<UserUiModel> = emptyList(),
     val tagSearch: List<TagUiModel> = emptyList(),
     val selectedTabIndex: Int = 0,
+    val errorMessage: String = ""
 )

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchViewModel.kt
@@ -35,7 +35,6 @@ class SearchViewModel @Inject constructor(
     private val searchUseCase: SearchUseCase,
 ) : ViewModel() {
 
-    val searchTextField = TextFieldState()
     private val _uiState = MutableStateFlow(SearchUiState())
     val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
 
@@ -54,7 +53,7 @@ class SearchViewModel @Inject constructor(
 
     private suspend fun getSearch() {
         when {
-            searchTextField.text.isEmpty() || searchTextField.text.isBlank() -> {
+            _uiState.value.searchTextField.text.isEmpty() || _uiState.value.searchTextField.text.isBlank() -> {
                 if (_uiState.value.selectedTabIndex == 0) {
                     getUserSearchHistory()
                 }
@@ -71,7 +70,7 @@ class SearchViewModel @Inject constructor(
     private suspend fun getUserSearch() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = "")
-            searchUseCase.getUserSearchUseCase(searchTextField.text.toString(), 10).onSuccess {
+            searchUseCase.getUserSearchUseCase(_uiState.value.searchTextField.text.toString(), 10).onSuccess {
                 _uiState.value = _uiState.value.copy(isLoading = false, userSearch = it.map { it.toUiModel() })
             }.onFailure {
                 _uiState.value = _uiState.value.copy(isLoading = false, errorMessage = (it as RemoteError).toStringForUser())
@@ -114,7 +113,7 @@ class SearchViewModel @Inject constructor(
     private fun getTagSearch() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = "")
-            searchUseCase.getTagSearchUseCase(searchTextField.text.toString(), 10).onSuccess {
+            searchUseCase.getTagSearchUseCase(_uiState.value.searchTextField.text.toString(), 10).onSuccess {
                 _uiState.value = _uiState.value.copy(isLoading = false, tagSearch = it.map { it.toUiModel() })
             }.onFailure {
                 _uiState.value = _uiState.value.copy(isLoading = false)

--- a/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/main/search/SearchViewModel.kt
@@ -40,7 +40,7 @@ class SearchViewModel @Inject constructor(
     val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
 
     init {
-        searchTextField.textAsFlow().debounce(300).onEach {
+        _uiState.value.searchTextField.textAsFlow().debounce(300).onEach {
             getSearch()
         }.launchIn(viewModelScope)
         getUserSearchHistory()

--- a/app/src/main/java/com/grusie/sharingmap/ui/navigation/main/MainBottomNavGraph.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/navigation/main/MainBottomNavGraph.kt
@@ -12,10 +12,10 @@ import com.grusie.sharingmap.ui.main.edit.EditScreen
 import com.grusie.sharingmap.ui.main.home.HomeScreen
 import com.grusie.sharingmap.ui.main.map.MapScreen
 import com.grusie.sharingmap.ui.main.map.SearchMapScreen
-import com.grusie.sharingmap.ui.main.mypage.MyPageScreen
+import com.grusie.sharingmap.ui.main.mypage.MyPageRoute
 import com.grusie.sharingmap.ui.main.mypage.archivecollection.ArchiveCollectionScreen
 import com.grusie.sharingmap.ui.main.mypage.user.UserScreen
-import com.grusie.sharingmap.ui.main.search.SearchScreen
+import com.grusie.sharingmap.ui.main.search.SearchRoute
 import com.grusie.sharingmap.ui.model.StorageUiModel
 import com.grusie.sharingmap.ui.model.TagUiModel
 import com.grusie.sharingmap.ui.model.UserUiModel
@@ -33,10 +33,40 @@ fun MainBottomNavGraph(navController: NavHostController, onBackPressed: () -> Un
             EditScreen(navController = navController)
         }
         composable(MainBottomNavItem.Search.screenRoute) {
-            SearchScreen(navController = navController)
+            SearchRoute(
+                onNavigationClick = { navController.popBackStack() },
+                onUserItemClick = {
+                    navController.navigate(
+                        NavItem.User.screenRoute + "?user=${
+                            Gson().toJson(
+                                it
+                            )
+                        }"
+                    )
+                },
+                onTagItemClick = {
+                    navController.navigate(
+                        NavItem.FeedCollection.screenRoute + "?tag=${
+                            Gson().toJson(
+                                it
+                            )
+                        }"
+                    )
+                }
+            )
         }
         composable(MainBottomNavItem.MyPage.screenRoute) {
-            MyPageScreen(navController = navController)
+            MyPageRoute(onUserClick = {
+                navController.navigate(NavItem.User.screenRoute + "?user=${Gson().toJson(it)}")
+            }, onStorageClick = {
+                navController.navigate(
+                    NavItem.FeedCollection.screenRoute + "?storage=${
+                        Gson().toJson(
+                            it
+                        )
+                    }"
+                )
+            })
         }
 
         composable(

--- a/app/src/main/java/com/grusie/sharingmap/ui/navigation/main/MainBottomNavGraph.kt
+++ b/app/src/main/java/com/grusie/sharingmap/ui/navigation/main/MainBottomNavGraph.kt
@@ -14,11 +14,10 @@ import com.grusie.sharingmap.ui.main.map.MapScreen
 import com.grusie.sharingmap.ui.main.map.SearchMapScreen
 import com.grusie.sharingmap.ui.main.mypage.MyPageRoute
 import com.grusie.sharingmap.ui.main.mypage.archivecollection.ArchiveCollectionScreen
-import com.grusie.sharingmap.ui.main.mypage.user.UserScreen
+import com.grusie.sharingmap.ui.main.mypage.user.UserRoute
 import com.grusie.sharingmap.ui.main.search.SearchRoute
 import com.grusie.sharingmap.ui.model.StorageUiModel
 import com.grusie.sharingmap.ui.model.TagUiModel
-import com.grusie.sharingmap.ui.model.UserUiModel
 
 @Composable
 fun MainBottomNavGraph(navController: NavHostController, onBackPressed: () -> Unit) {
@@ -37,7 +36,7 @@ fun MainBottomNavGraph(navController: NavHostController, onBackPressed: () -> Un
                 onNavigationClick = { navController.popBackStack() },
                 onUserItemClick = {
                     navController.navigate(
-                        NavItem.User.screenRoute + "?user=${
+                        NavItem.User.screenRoute + "?userId=${
                             Gson().toJson(
                                 it
                             )
@@ -88,12 +87,35 @@ fun MainBottomNavGraph(navController: NavHostController, onBackPressed: () -> Un
         }
 
         composable(
-            NavItem.User.screenRoute + "?user={user}",
-            arguments = listOf(navArgument("user") { type = NavType.StringType })
+            NavItem.User.screenRoute + "?userId={userId}",
+            arguments = listOf(navArgument("userId") { type = NavType.StringType })
         ) {
-            val userJsonString = it.arguments?.getString("user")
-            val user = Gson().fromJson(userJsonString, UserUiModel::class.java)
-            UserScreen(navController = navController, user = user)
+            val userId = it.arguments?.getString("userId")?.toLong()
+            if (userId != null) {
+                UserRoute(
+                    userId = userId,
+                    onNavigateClick = { navController.popBackStack() },
+                    onUserClick = {
+                        navController.navigate(
+                            NavItem.User.screenRoute + "?userId=${
+                                Gson().toJson(
+                                    it
+                                )
+                            }"
+                        )
+                    },
+                    onStorageClick = {
+                        navController.navigate(
+                            NavItem.FeedCollection.screenRoute + "?storage=${
+                                Gson().toJson(
+                                    it
+                                )
+                            }"
+                        )
+                    }
+                )
+            }
+            /*UserScreen(navController = navController, user = user)*/
         }
 
         composable(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,9 @@
 <resources>
     <string name="app_name">SharingMap</string>
 
+    <!-- All -->
+    <string name="loading_prgress">로딩 프로그레스</string>
+
     <!-- Main Bottom Nav -->
     <string name="main_bottom_nav_home">home</string>
     <string name="main_bottom_nav_map">map</string>
@@ -38,6 +41,7 @@
     <string name="mypage_storage_title">보관함 제목</string>
     <string name="mypage_storage_title_hint_text">제목 입력…</string>
     <string name="mypage_storage_create_title">생성</string>
+    <string name="mypage_limited_text_button">더보기/접기 버튼</string>
 
     <!-- Custom Bottom Sheet -->
     <string name="custom_bottom_sheet_cancel_text">취소</string>

--- a/data/src/main/java/com/gruise/data/dao/UserSearchDao.kt
+++ b/data/src/main/java/com/gruise/data/dao/UserSearchDao.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface UserSearchDao {
-    @Query("SELECT * FROM userSearch ORDER BY ID DESC ")
+    @Query("SELECT * FROM userSearch ORDER BY createdAt DESC ")
     fun getAll(): Flow<List<LocalUserSearch>>
 
     @Query("DELETE FROM userSearch")

--- a/data/src/main/java/com/gruise/data/database/UserSearchDatabase.kt
+++ b/data/src/main/java/com/gruise/data/database/UserSearchDatabase.kt
@@ -7,7 +7,7 @@ import com.gruise.data.model.LocalUserSearch
 
 @Database(
     entities = [LocalUserSearch::class],
-    version = 2,
+    version = 1,
     exportSchema = false
 )
 abstract class UserSearchDatabase: RoomDatabase() {

--- a/data/src/main/java/com/gruise/data/datasource/user/UserDataSource.kt
+++ b/data/src/main/java/com/gruise/data/datasource/user/UserDataSource.kt
@@ -4,5 +4,5 @@ import com.gruise.data.model.UserDto
 
 interface UserDataSource {
     suspend fun getMyInfo(): Result<UserDto>
-
+    suspend fun getUserByUserId(userId: Long): Result<UserDto>
 }

--- a/data/src/main/java/com/gruise/data/datasource/user/UserRemoteDataSource.kt
+++ b/data/src/main/java/com/gruise/data/datasource/user/UserRemoteDataSource.kt
@@ -10,4 +10,8 @@ class UserRemoteDataSource @Inject constructor(
     override suspend fun getMyInfo(): Result<UserDto> {
         return userService.getMyInfo()
     }
+
+    override suspend fun getUserByUserId(userId: Long): Result<UserDto> {
+        return userService.getUserByUserId(userId)
+    }
 }

--- a/data/src/main/java/com/gruise/data/di/UseCaseModule.kt
+++ b/data/src/main/java/com/gruise/data/di/UseCaseModule.kt
@@ -28,6 +28,7 @@ import com.gruise.domain.usecase.search.SearchUseCase
 import com.gruise.domain.usecase.storage.GetStoragesUseCase
 import com.gruise.domain.usecase.storage.StorageUseCase
 import com.gruise.domain.usecase.user.GetMyInfoUseCase
+import com.gruise.domain.usecase.user.GetUserByUserIdUseCase
 import com.gruise.domain.usecase.user.UserUseCase
 import dagger.Module
 import dagger.Provides
@@ -74,7 +75,8 @@ object UseCaseModule {
         userRepository: UserRepository
     ): UserUseCase {
         return UserUseCase(
-            getMyInfoUseCase = GetMyInfoUseCase(userRepository)
+            getMyInfoUseCase = GetMyInfoUseCase(userRepository),
+            getUserByUserIdUseCase = GetUserByUserIdUseCase(userRepository)
         )
     }
 

--- a/data/src/main/java/com/gruise/data/mapper/SearchMapper.kt
+++ b/data/src/main/java/com/gruise/data/mapper/SearchMapper.kt
@@ -23,7 +23,8 @@ fun User.toLocalData(): LocalUserSearch {
         profileImage = profileImage,
         name = name,
         description = description ?: "",
-        email = email
+        email = email,
+        createdAt = System.currentTimeMillis()
     )
 }
 
@@ -32,5 +33,5 @@ fun LocalTagSearch.toDomain(): Tag {
 }
 
 fun Tag.toLocalData(): LocalTagSearch {
-    return LocalTagSearch(tagId = tagId, tagName = tagName, tagCount = tagCount)
+    return LocalTagSearch(tagId = tagId, tagName = tagName, tagCount = tagCount, createdAt = System.currentTimeMillis())
 }

--- a/data/src/main/java/com/gruise/data/model/LocalTagSearch.kt
+++ b/data/src/main/java/com/gruise/data/model/LocalTagSearch.kt
@@ -7,12 +7,12 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "tagSearch")
 data class LocalTagSearch(
     @ColumnInfo(name = "tag_id")
+    @PrimaryKey
     val tagId: Long,
     @ColumnInfo(name = "tag_name")
     val tagName: String,
     @ColumnInfo(name = "tag_count")
     val tagCount: Int,
-) {
-    @PrimaryKey(autoGenerate = true)
-    var id: Long = 0
-}
+    @ColumnInfo(name = "createdAt")
+    val createdAt: Long,
+)

--- a/data/src/main/java/com/gruise/data/model/LocalUserSearch.kt
+++ b/data/src/main/java/com/gruise/data/model/LocalUserSearch.kt
@@ -7,6 +7,7 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "userSearch")
 data class LocalUserSearch(
     @ColumnInfo(name = "user_id")
+    @PrimaryKey
     val userId: Long,
     @ColumnInfo(name = "profile_image")
     val profileImage: String,
@@ -16,7 +17,6 @@ data class LocalUserSearch(
     val description: String,
     @ColumnInfo(name = "email")
     val email: String?,
-) {
-    @PrimaryKey(autoGenerate = true)
-    var id: Long = 0
-}
+    @ColumnInfo(name = "createdAt")
+    val createdAt: Long,
+)

--- a/data/src/main/java/com/gruise/data/repository/DefaultUserRepository.kt
+++ b/data/src/main/java/com/gruise/data/repository/DefaultUserRepository.kt
@@ -12,4 +12,8 @@ class DefaultUserRepository @Inject constructor(
     override suspend fun getMyInfo(): Result<User> {
         return userRemoteDataSource.getMyInfo().map { it.toDomain() }
     }
+
+    override suspend fun getUserByUserId(userId: Long): Result<User> {
+        return userRemoteDataSource.getUserByUserId(userId).map { it.toDomain() }
+    }
 }

--- a/data/src/main/java/com/gruise/data/service/UserService.kt
+++ b/data/src/main/java/com/gruise/data/service/UserService.kt
@@ -2,8 +2,14 @@ package com.gruise.data.service
 
 import com.gruise.data.model.UserDto
 import retrofit2.http.GET
+import retrofit2.http.Path
 
 interface UserService {
     @GET("api/users/@me")
     suspend fun getMyInfo(): Result<UserDto>
+
+    @GET("api/users/{userId}")
+    suspend fun getUserByUserId(
+        @Path("userId") userId: Long
+    ): Result<UserDto>
 }

--- a/domain/src/main/java/com/gruise/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/com/gruise/domain/repository/UserRepository.kt
@@ -4,4 +4,5 @@ import com.gruise.domain.model.User
 
 interface UserRepository {
     suspend fun getMyInfo(): Result<User>
+    suspend fun getUserByUserId(userId: Long): Result<User>
 }

--- a/domain/src/main/java/com/gruise/domain/usecase/user/GetUserByUserIdUseCase.kt
+++ b/domain/src/main/java/com/gruise/domain/usecase/user/GetUserByUserIdUseCase.kt
@@ -1,0 +1,13 @@
+package com.gruise.domain.usecase.user
+
+import com.gruise.domain.model.User
+import com.gruise.domain.repository.UserRepository
+import javax.inject.Inject
+
+class GetUserByUserIdUseCase @Inject constructor(
+    private val userRepository: UserRepository
+){
+    suspend operator fun invoke(userId: Long): Result<User> {
+        return userRepository.getUserByUserId(userId)
+    }
+}

--- a/domain/src/main/java/com/gruise/domain/usecase/user/UserUseCase.kt
+++ b/domain/src/main/java/com/gruise/domain/usecase/user/UserUseCase.kt
@@ -1,5 +1,6 @@
 package com.gruise.domain.usecase.user
 
 data class UserUseCase(
-    val getMyInfoUseCase: GetMyInfoUseCase
+    val getMyInfoUseCase: GetMyInfoUseCase,
+    val getUserByUserIdUseCase: GetUserByUserIdUseCase
 )


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #50 

## 📝 작업 요약

UI state 방법 수정 및 UI 테스트 코드 작성

## 🔎 작업 상세 설명

- 기존의 sealed class로 관리하던 UI state를 data class로 관리하도록 수정했습니다
-> sealed class를 사용하니 계속된 분기처리와 타입캐스팅을 계속적으로 해주어야하는 불편한 점이 있었고 data class를 통해 상태를 관리하는게 편할 것 같아 위와 같이 수정했습니다.

- UI 테스트 코드 작성
-> Screen을 테스트하는 코드를 작성하기 위해 Screen이 viewmodel을 파라미터로 받으면 테스트하기 어렵다고 판단하여 각 스크린마다 Route 컴포저블 함수를 생성하여 Route에서 상태와 스크린을 관리하는 방법으로 구현했습니다.

- room에서 primary key 수정하고 정렬을 위해 createdAt 컬럼 추가
